### PR TITLE
Consolidate optional dependency declarations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ viz = [
   "matplotlib>=3.8",
   # 必要なら "imageio>=2.34" なども
 ]
+dev = [
+  "pre-commit>=3.5",
+]
 
 [tool.black]
 line-length = 88
@@ -35,9 +38,4 @@ extend-exclude = ["build", "dist"]
 dev = [
     "pytest>=8.4.2",
     "pytest-cov>=6.3.0",
-]
-
-[project.optional-dependencies]
-dev = [
-    "pre-commit>=3.5",
 ]


### PR DESCRIPTION
## Summary
- combine `viz` and `dev` optional dependencies into a single `[project.optional-dependencies]` section

## Testing
- `pre-commit run --files pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_68bd77abd430832893c2d2b4d9af40fd