### PR TITLE
refactor: move pre-commit to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ requires-python = ">=3.12"
 
 dependencies = [
     "numpy",
-    "pre-commit",
 ]
 
 [project.optional-dependencies]
 viz = [
   "matplotlib>=3.8",
   # 必要なら "imageio>=2.34" なども
+]
+dev = [
+  "pre-commit>=3.5",
 ]
 
 [tool.black]
@@ -35,9 +37,4 @@ extend-exclude = ["build", "dist"]
 dev = [
     "pytest>=8.4.2",
     "pytest-cov>=6.3.0",
-]
-
-[project.optional-dependencies]
-dev = [
-    "pre-commit>=3.5",
 ]


### PR DESCRIPTION
## Summary
- remove pre-commit from runtime dependencies
- ensure pre-commit is a dev optional dependency

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd77b7683c8328a759a06ad6d7c220