### PR TITLE
chore: target Python 3.12 for Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,14 @@ viz = [
   "matplotlib>=3.8",
   # 必要なら "imageio>=2.34" なども
 ]
+dev = [
+  "pre-commit>=3.5",
+]
 
 [tool.black]
 line-length = 88
-target-version = ["py310"]
-extend-exclude = ["build", "dist"]
+target-version = ["py312"]
+extend-exclude = "(build|dist)"
 
 [tool.isort]
 profile = "black"
@@ -35,9 +38,4 @@ extend-exclude = ["build", "dist"]
 dev = [
     "pytest>=8.4.2",
     "pytest-cov>=6.3.0",
-]
-
-[project.optional-dependencies]
-dev = [
-    "pre-commit>=3.5",
 ]


### PR DESCRIPTION
## Summary
- target Python 3.12 in Black configuration
- consolidate optional dependencies and fix Black exclude pattern

## Testing
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd77e9f484832893fa8306be6e245b